### PR TITLE
Fix for UTF in request.GET  ulogin_tags.py

### DIFF
--- a/django_ulogin/templatetags/ulogin_tags.py
+++ b/django_ulogin/templatetags/ulogin_tags.py
@@ -29,7 +29,7 @@ def get_redirect_url(request):
         })
         request.GET = get
 
-    return urlquote("{request_url}?{query_string}".format(
+    return urlquote(u"{request_url}?{query_string}".format(
         request_url=request.build_absolute_uri(r('ulogin_postback')),
         query_string=smart_unicode(urllib.unquote(request.GET.urlencode()))
     ))


### PR DESCRIPTION
Если в GET параметрах есть Unicode строки, то .format() выдает ошибку
'ascii' codec can't encode characters in position 29-38: ordinal not in range(128)

Проблема также описана здесь
https://github.com/ulogin/ulogin-Django/issues/1