### PR TITLE
FIX: Python 3 has no urllib.unquote

### DIFF
--- a/django_ulogin/templatetags/ulogin_tags.py
+++ b/django_ulogin/templatetags/ulogin_tags.py
@@ -28,8 +28,11 @@ def get_redirect_url(request):
             FLD: request.build_absolute_uri(request.path_info)
         })
         request.GET = get
-        
-    unquote = urllib.unquote if hasattr(urllib,'unquote') else urllib.parse.unquote
+
+    if hasattr(urllib, 'unquote'):
+        unquote = urllib.unquote
+    else:
+        unquote = urllib.parse.unquote
 
     return urlquote("{request_url}?{query_string}".format(
         request_url=request.build_absolute_uri(r('ulogin_postback')),

--- a/django_ulogin/templatetags/ulogin_tags.py
+++ b/django_ulogin/templatetags/ulogin_tags.py
@@ -28,10 +28,12 @@ def get_redirect_url(request):
             FLD: request.build_absolute_uri(request.path_info)
         })
         request.GET = get
+        
+    unquote = urllib.unquote if hasattr(urllib,'unquote') else urllib.parse.unquote
 
     return urlquote("{request_url}?{query_string}".format(
         request_url=request.build_absolute_uri(r('ulogin_postback')),
-        query_string=smart_unicode(urllib.unquote(request.GET.urlencode()))
+        query_string=smart_unicode(unquote(request.GET.urlencode()))
     ))
 
 


### PR DESCRIPTION
Исправлено: при вставке {% ulogin_widget %} в главный шаблон выходит борода ошибок.
Fixed: {% ulogin_widget %} in main template makes error.

`python --version`: Python 3.4.3
`pip freeze`:
```
Django==1.8.6
django-ulogin==0.2.3
gunicorn==19.3.0
mock==1.3.0
pbr==1.8.1
psycopg2==2.6.1
requests==2.8.1
six==1.10.0
wheel==0.24.0
```